### PR TITLE
Add Renovate custom manager for DV Maven extension in README

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,16 @@
     "github>gradle/renovate-agent//presets/dv-automerge-minor.json5",
     ":disableDependencyDashboard"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["README\\.md$"],
+      "matchStrings": ["develocity-maven-extension</artifactId>\\s*<version>(?<currentValue>[^<]+)</version>"],
+      "depNameTemplate": "com.gradle:develocity-maven-extension",
+      "datasourceTemplate": "maven",
+      "registryUrlTemplate": "https://repo1.maven.org/maven2"
+    }
+  ],
   "packageRules": [
     {
       "matchFileNames": ["src/it/quarkus-latest/**"],


### PR DESCRIPTION
## Summary
The Develocity Maven extension version in the `README.md` XML snippet is currently updated centrally from `gradle/dv-solutions` via custom upgrade workflows. This PR adds a Renovate `customManager` so this repo receives version update PRs directly.

This is part of a broader migration away from the centralized version upgrade workflows in `dv-solutions` toward each repo owning its own dependency updates via Renovate.

### What this changes
- Adds a `customManagers` entry to `.github/renovate.json5` that matches the `develocity-maven-extension` version in the XML snippet in `README.md`
- Renovate will now detect new versions from Maven Central and open PRs to update it

### What Renovate already handles for this repo
- Maven wrapper updates (built-in `maven-wrapper` manager)
- Maven dependency updates in `pom.xml` and `.mvn/extensions.xml` (built-in `maven` manager)
- GitHub Actions updates (built-in `github-actions` manager)